### PR TITLE
Make `%d` take `num` instead of `mixed`

### DIFF
--- a/hphp/hack/hhi/printf.hhi
+++ b/hphp/hack/hhi/printf.hhi
@@ -43,7 +43,7 @@ interface PlainSprintf {
   // It's common to pass floats; would be nice to type this as
   // 'number' once that type becomes available in userland.
  <<__Rx>>
-  public function format_d(mixed $s) : string;
+  public function format_d(num $s) : string;
  <<__Rx>>
   public function format_s(mixed $s) : string;
  <<__Rx>>


### PR DESCRIPTION
I did `invariant($some_condition, 'Id must be greater than zero %d', $array_key);`
Scratching my head why this was allowed and figuring out that `%d` takes `mixed` in `PlainSprintf`, but `int` in `HH\Lib\Str\SprintfFormat`.

The docblock specifies `?int`

> function format_d(?int $s) : string;

But then again, another comment also specifies that it would be nice if this was `number` (`num`) instead.

> // It's common to pass floats; would be nice to type this as
> // 'number' once that type becomes available in userland.

It might be nice to make both formatters agree and end this confusion about what formatting interface what function is using. Either make `Str\format` weaker to take `num` too.
Or use `num` in `PlainSprintf` as an intermediate step to migrate to `int` later.